### PR TITLE
pass the handle to nfc_close before making it nil

### DIFF
--- a/2.0/nfc/device.go
+++ b/2.0/nfc/device.go
@@ -92,8 +92,8 @@ func (d Device) Close() error {
 		return nil
 	}
 
-	*d.d = nil
 	C.nfc_close(*d.d)
+	*d.d = nil
 
 	return nil
 }


### PR DESCRIPTION
The following is a one line change to nfc/device.go . Earlier code was not closing the NFC reader. In my case, it was clearly visible with an led on SCL3711 staying lit after device.Close(). This one line swap fixed it.  Please note that this is to the 2.0 branch. I could not compile the dev branch, probably because of version difference with libnfs. Since 2.0 is your stable branch, I made it for 2.0. Please make the same change to dev branch as well.

     diff --git a/2.0/nfc/device.go b/2.0/nfc/device.go
     index 3bf6a09..c8fe55b 100644
     --- a/2.0/nfc/device.go
     +++ b/2.0/nfc/device.go
     @@ -92,8 +92,8 @@ func (d Device) Close() error {
                     return nil
             }

     -       *d.d = nil
             C.nfc_close(*d.d)
    +       *d.d = nil
     
             return nil
      }
